### PR TITLE
Add installation using virtualenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # cvfy-lib
 
-Installation
+## Installation
 
 1. sudo apt install python-dev python-numpy python-opencv
-2. pip install -r requirements.txt
+2. virtualenv venv
+3. source venv/bin/activate
+4. pip install -r requirements.txt
 
-Documentation
+## Documentation
 
 Within the webapp itself. See [CVFY-Frontend](https://github.com/Cloud-CV/cvfy-frontend).


### PR DESCRIPTION
pip install would fail without root permissions if Python is installed in root. Use virtualenv instead. 