### PR TITLE
Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+sudo: required
+language: python
+
+python:
+  - "2.7"
+  - "3.4"
+
+before_install:
+  - pip install -U pip
+
+install:
+  - pip install opencv-python
+  - pip install numpy
+  - pip install -r requirements.txt
+
+cache:
+  directories:
+    - origami-lib

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 before_install:
   - pip install -U pip
 
-install:
+script:
   - pip install opencv-python
   - pip install numpy
   - pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-flask
-flask-cors
-requests
-python-magic
-tornado
+Flask==0.12.2
+Flask-Cors==3.0.3
+requests==2.18.4
+python-magic==0.4.13
+tornado==4.5.2


### PR DESCRIPTION
Added Travis CI Python for both 2.7 and 3.4. Under the install header, I attempted to recreate the process in the readme, as OpenCV and Numpy were supposed to be installed before the requirements rather than as part of them.