### PR TITLE
Integrates origami-lib with TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+sudo: required
+language: python
+
+python:
+  - "2.7"
+
+before_script:
+  - pip install pytest
+  - pip install numpy
+  - pip install opencv-python
+  - pip install -r requirements.txt
+  - python origami-lib/test/server_textimageinput.py &
+  - sleep 1
+
+script:
+  - cd origami-lib/test/
+  - pytest
+
+cache: pip


### PR DESCRIPTION
Adds a .travis.yml file and runs some script to install the library.
No tests are currently there so it just installs origami-lib for now.

My fork:
https://github.com/idealadarsh/origami-lib

Travis build:
https://travis-ci.org/idealadarsh/origami-lib/builds/311200222

Related GCI task: 
https://codein.withgoogle.com/dashboard/task-instances/4717290908024832/